### PR TITLE
fix: Removed default value from checkout step.

### DIFF
--- a/.github/workflows/autopr.yml
+++ b/.github/workflows/autopr.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        ref: main
         fetch-depth: 1
     - name: AutoPR
       uses: docker://ghcr.io/irgolic/autopr:latest


### PR DESCRIPTION
I think it's best to leave this at the default so that people copying it to a repository with a master branch like master or whatever doesn't get in trouble.